### PR TITLE
add `ocaml-flake`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -998,11 +998,11 @@
         "treefmt": "treefmt"
       },
       "locked": {
-        "lastModified": 1698473395,
-        "narHash": "sha256-ZdtvTFxtHymQUdoe+ucor3inYwWKiyticouYXqA9A74=",
+        "lastModified": 1698559786,
+        "narHash": "sha256-xU5wecrSDJgNuykuAKOJBnEjzVn5YJSP3dg2aMOAqnA=",
         "owner": "yusdacra",
         "repo": "nix-cargo-integration",
-        "rev": "392592a7278053752fbeab17b9c904f7e9d1b0b1",
+        "rev": "901f78297706c03a792216af39a8b429952438ef",
         "type": "github"
       },
       "original": {
@@ -1228,22 +1228,6 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1698336494,
-        "narHash": "sha256-sO72WDBKyijYD1GcKPlGsycKbMBiTJMBCnmOxLAs880=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "808c0d8c53c7ae50f82aca8e7df263225cf235bf",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_6": {
-      "locked": {
         "lastModified": 1675940568,
         "narHash": "sha256-epG6pOT9V0kS+FUqd7R6/CWkgnZx2DMT5Veqo+y6G3c=",
         "owner": "nixos",
@@ -1258,7 +1242,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_7": {
+    "nixpkgs_6": {
       "locked": {
         "lastModified": 1695644571,
         "narHash": "sha256-asS9dCCdlt1lPq0DLwkVBbVoEKuEuz+Zi3DG7pR/RxA=",
@@ -1297,19 +1281,23 @@
         "haumea": "haumea",
         "mirage-opam-overlays": "mirage-opam-overlays",
         "namaka": "namaka",
-        "nixpkgs": "nixpkgs_5",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
         "opam-nix": "opam-nix",
         "opam-overlays": "opam-overlays",
         "opam-repository": "opam-repository",
         "opam2json": "opam2json",
-        "treefmt-nix": "treefmt-nix_2"
+        "treefmt-nix": [
+          "treefmt-nix"
+        ]
       },
       "locked": {
-        "lastModified": 1698533389,
-        "narHash": "sha256-HdWQVQJ0MasRSujdkggNS+qXw4uKNGVhR+7leVkTbRo=",
+        "lastModified": 1698533787,
+        "narHash": "sha256-34vxdDWLMUPtzQbAXN8rVpMuvFKHlJAUkQ/3PPS0NXw=",
         "owner": "9glenda",
         "repo": "ocaml-flake",
-        "rev": "7b6b9e56b5a58c516ebf73742ad0422ea1e05264",
+        "rev": "aa1ac046566521c61381ec2e022cfa206bb6f018",
         "type": "github"
       },
       "original": {
@@ -1610,17 +1598,17 @@
         "proc-flake": "proc-flake",
         "process-compose-flake": "process-compose-flake",
         "std": "std",
-        "treefmt-nix": "treefmt-nix_3"
+        "treefmt-nix": "treefmt-nix_2"
       }
     },
     "rust-overlay": {
       "flake": false,
       "locked": {
-        "lastModified": 1698458995,
-        "narHash": "sha256-nF8E8Ur5NggwPQNp3w/fddWmQrNEwCm0dgz6tk8Ew6E=",
+        "lastModified": 1698545594,
+        "narHash": "sha256-Bf0UKNXBOg1OWe3GkfUNKpAlihiuuhcyzPDcMfJvUOg=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "571fee291b386dd6fe0d125bc20a7c7b3ad042ac",
+        "rev": "66eb7c2fb4597c94e66a4124ee77d9827e46c14f",
         "type": "github"
       },
       "original": {
@@ -1660,7 +1648,7 @@
           "std",
           "blank"
         ],
-        "nixpkgs": "nixpkgs_6",
+        "nixpkgs": "nixpkgs_5",
         "paisano": "paisano",
         "paisano-tui": "paisano-tui",
         "terranix": [
@@ -1772,28 +1760,7 @@
     },
     "treefmt-nix_2": {
       "inputs": {
-        "nixpkgs": [
-          "ocaml-flake",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1698438538,
-        "narHash": "sha256-AWxaKTDL3MtxaVTVU5lYBvSnlspOS0Fjt8GxBgnU0Do=",
-        "owner": "numtide",
-        "repo": "treefmt-nix",
-        "rev": "5deb8dc125a9f83b65ca86cf0c8167c46593e0b1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "treefmt-nix",
-        "type": "github"
-      }
-    },
-    "treefmt-nix_3": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_7"
+        "nixpkgs": "nixpkgs_6"
       },
       "locked": {
         "lastModified": 1698438538,

--- a/flake.lock
+++ b/flake.lock
@@ -53,6 +53,21 @@
     },
     "call-flake": {
       "locked": {
+        "lastModified": 1697937646,
+        "narHash": "sha256-bmhE1TmrJG4ba93l9WQTLuYM53kwGQAjYHRvHOeuxWU=",
+        "owner": "divnix",
+        "repo": "call-flake",
+        "rev": "8fea00392fe00e776007b3776aa61c212485d58c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "divnix",
+        "repo": "call-flake",
+        "type": "github"
+      }
+    },
+    "call-flake_2": {
+      "locked": {
         "lastModified": 1687380775,
         "narHash": "sha256-bmhE1TmrJG4ba93l9WQTLuYM53kwGQAjYHRvHOeuxWU=",
         "owner": "divnix",
@@ -373,6 +388,22 @@
     "flake-compat_3": {
       "flake": false,
       "locked": {
+        "lastModified": 1627913399,
+        "narHash": "sha256-hY8g6H2KFL8ownSiFeMOjwPC8P0ueXpCVEbxgda3pko=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "12c64ca55c1014cdc1b16ed5a804aa8576601ff2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_4": {
+      "flake": false,
+      "locked": {
         "lastModified": 1673956053,
         "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
         "owner": "edolstra",
@@ -480,7 +511,40 @@
         "type": "indirect"
       }
     },
+    "flake-parts_6": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib_4"
+      },
+      "locked": {
+        "lastModified": 1696343447,
+        "narHash": "sha256-B2xAZKLkkeRFG5XcHHSXXcP7To9Xzr59KXeZiRf4vdQ=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "c9afaba3dfa4085dbd2ccb38dfade5141e33d9d4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
     "flake-root": {
+      "locked": {
+        "lastModified": 1692742795,
+        "narHash": "sha256-f+Y0YhVCIJ06LemO+3Xx00lIcqQxSKJHXT/yk1RTKxw=",
+        "owner": "srid",
+        "repo": "flake-root",
+        "rev": "d9a70d9c7a5fd7f3258ccf48da9335e9b47c3937",
+        "type": "github"
+      },
+      "original": {
+        "owner": "srid",
+        "repo": "flake-root",
+        "type": "github"
+      }
+    },
+    "flake-root_2": {
       "locked": {
         "lastModified": 1692742795,
         "narHash": "sha256-f+Y0YhVCIJ06LemO+3Xx00lIcqQxSKJHXT/yk1RTKxw=",
@@ -541,6 +605,21 @@
       }
     },
     "flake-utils_2": {
+      "locked": {
+        "lastModified": 1638122382,
+        "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "74f7e4319258e287b0f9cb95426c9853b282730b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_3": {
       "inputs": {
         "systems": "systems_3"
       },
@@ -666,6 +745,27 @@
     "haumea": {
       "inputs": {
         "nixpkgs": [
+          "ocaml-flake",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1697205539,
+        "narHash": "sha256-gHEy0Q+eEQJkWl6/DpFxXPOlTx/lMU7Pvs/bwoq4OhI=",
+        "owner": "nix-community",
+        "repo": "haumea",
+        "rev": "fc119c500189f739fec7ad33d111f9c92910eccf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "haumea",
+        "type": "github"
+      }
+    },
+    "haumea_2": {
+      "inputs": {
+        "nixpkgs": [
           "std",
           "lib"
         ]
@@ -787,6 +887,22 @@
         "type": "indirect"
       }
     },
+    "mirage-opam-overlays": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1661959605,
+        "narHash": "sha256-CPTuhYML3F4J58flfp3ZbMNhkRkVFKmBEYBZY5tnQwA=",
+        "owner": "dune-universe",
+        "repo": "mirage-opam-overlays",
+        "rev": "05f1c1823d891ce4d8adab91f5db3ac51d86dc0b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "dune-universe",
+        "repo": "mirage-opam-overlays",
+        "type": "github"
+      }
+    },
     "mission-control": {
       "locked": {
         "lastModified": 1690573269,
@@ -815,6 +931,31 @@
       "original": {
         "owner": "yusdacra",
         "repo": "mk-naked-shell",
+        "type": "github"
+      }
+    },
+    "namaka": {
+      "inputs": {
+        "haumea": [
+          "ocaml-flake",
+          "haumea"
+        ],
+        "nixpkgs": [
+          "ocaml-flake",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1698461546,
+        "narHash": "sha256-DjMAvl1IzCMNWAY15UsDU+4CUaid2Z8yKwFbENz5w28=",
+        "owner": "nix-community",
+        "repo": "namaka",
+        "rev": "75784dbbdf6d4bbfeb03d4f9291ea51533e25b75",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "namaka",
         "type": "github"
       }
     },
@@ -956,6 +1097,24 @@
         "type": "github"
       }
     },
+    "nixpkgs-lib_4": {
+      "locked": {
+        "dir": "lib",
+        "lastModified": 1696019113,
+        "narHash": "sha256-X3+DKYWJm93DRSdC5M6K5hLqzSya9BjibtBsuARoPco=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f5892ddac112a1e9b3612c39af1b72987ee5783a",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs-regression": {
       "locked": {
         "lastModified": 1643052045,
@@ -1069,6 +1228,22 @@
     },
     "nixpkgs_5": {
       "locked": {
+        "lastModified": 1698336494,
+        "narHash": "sha256-sO72WDBKyijYD1GcKPlGsycKbMBiTJMBCnmOxLAs880=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "808c0d8c53c7ae50f82aca8e7df263225cf235bf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_6": {
+      "locked": {
         "lastModified": 1675940568,
         "narHash": "sha256-epG6pOT9V0kS+FUqd7R6/CWkgnZx2DMT5Veqo+y6G3c=",
         "owner": "nixos",
@@ -1083,7 +1258,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_6": {
+    "nixpkgs_7": {
       "locked": {
         "lastModified": 1695644571,
         "narHash": "sha256-asS9dCCdlt1lPq0DLwkVBbVoEKuEuz+Zi3DG7pR/RxA=",
@@ -1114,9 +1289,130 @@
         "type": "github"
       }
     },
-    "paisano": {
+    "ocaml-flake": {
       "inputs": {
         "call-flake": "call-flake",
+        "flake-parts": "flake-parts_6",
+        "flake-root": "flake-root_2",
+        "haumea": "haumea",
+        "mirage-opam-overlays": "mirage-opam-overlays",
+        "namaka": "namaka",
+        "nixpkgs": "nixpkgs_5",
+        "opam-nix": "opam-nix",
+        "opam-overlays": "opam-overlays",
+        "opam-repository": "opam-repository",
+        "opam2json": "opam2json",
+        "treefmt-nix": "treefmt-nix_2"
+      },
+      "locked": {
+        "lastModified": 1698533389,
+        "narHash": "sha256-HdWQVQJ0MasRSujdkggNS+qXw4uKNGVhR+7leVkTbRo=",
+        "owner": "9glenda",
+        "repo": "ocaml-flake",
+        "rev": "7b6b9e56b5a58c516ebf73742ad0422ea1e05264",
+        "type": "github"
+      },
+      "original": {
+        "owner": "9glenda",
+        "repo": "ocaml-flake",
+        "type": "github"
+      }
+    },
+    "opam-nix": {
+      "inputs": {
+        "flake-compat": "flake-compat_3",
+        "flake-utils": "flake-utils_2",
+        "mirage-opam-overlays": [
+          "ocaml-flake",
+          "mirage-opam-overlays"
+        ],
+        "nixpkgs": [
+          "ocaml-flake",
+          "nixpkgs"
+        ],
+        "opam-overlays": [
+          "ocaml-flake",
+          "opam-overlays"
+        ],
+        "opam-repository": [
+          "ocaml-flake",
+          "opam-repository"
+        ],
+        "opam2json": [
+          "ocaml-flake",
+          "opam2json"
+        ]
+      },
+      "locked": {
+        "lastModified": 1698410402,
+        "narHash": "sha256-GmNqvLcmCYTai/Pi4R0/UF5NxT8EGG4JJqwvp5/uL+A=",
+        "owner": "tweag",
+        "repo": "opam-nix",
+        "rev": "4d42f3d5a3161d7100b37c830a848fcf415409d5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tweag",
+        "repo": "opam-nix",
+        "type": "github"
+      }
+    },
+    "opam-overlays": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1697107826,
+        "narHash": "sha256-VvhNtBlgwsi/dlmU33z/4KKJN7Trj4OXMsq9G3eAPwc=",
+        "owner": "dune-universe",
+        "repo": "opam-overlays",
+        "rev": "24ca14c061b41323ac113d082865854c48588b32",
+        "type": "github"
+      },
+      "original": {
+        "owner": "dune-universe",
+        "repo": "opam-overlays",
+        "type": "github"
+      }
+    },
+    "opam-repository": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1698410171,
+        "narHash": "sha256-s42m0oqr/7cDWqiH2z6jILaXvGsmSLQloejRP1E9ekI=",
+        "owner": "ocaml",
+        "repo": "opam-repository",
+        "rev": "6ce4f1bb124b9fdd75cf5851fe8aeb07caccecbd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ocaml",
+        "repo": "opam-repository",
+        "type": "github"
+      }
+    },
+    "opam2json": {
+      "inputs": {
+        "nixpkgs": [
+          "ocaml-flake",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1671540003,
+        "narHash": "sha256-5pXfbUfpVABtKbii6aaI2EdAZTjHJ2QntEf0QD2O5AM=",
+        "owner": "tweag",
+        "repo": "opam2json",
+        "rev": "819d291ea95e271b0e6027679de6abb4d4f7f680",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tweag",
+        "repo": "opam2json",
+        "type": "github"
+      }
+    },
+    "paisano": {
+      "inputs": {
+        "call-flake": "call-flake_2",
         "nixpkgs": [
           "std",
           "nixpkgs"
@@ -1226,8 +1522,8 @@
     },
     "pre-commit-hooks-nix": {
       "inputs": {
-        "flake-compat": "flake-compat_3",
-        "flake-utils": "flake-utils_2",
+        "flake-compat": "flake-compat_4",
+        "flake-utils": "flake-utils_3",
         "gitignore": "gitignore_2",
         "nixpkgs": [
           "nixpkgs"
@@ -1309,11 +1605,12 @@
         "mission-control": "mission-control",
         "nix-cargo-integration": "nix-cargo-integration",
         "nixpkgs": "nixpkgs_4",
+        "ocaml-flake": "ocaml-flake",
         "pre-commit-hooks-nix": "pre-commit-hooks-nix",
         "proc-flake": "proc-flake",
         "process-compose-flake": "process-compose-flake",
         "std": "std",
-        "treefmt-nix": "treefmt-nix_2"
+        "treefmt-nix": "treefmt-nix_3"
       }
     },
     "rust-overlay": {
@@ -1344,7 +1641,7 @@
           "blank"
         ],
         "dmerge": "dmerge",
-        "haumea": "haumea",
+        "haumea": "haumea_2",
         "incl": "incl",
         "lib": "lib",
         "makes": [
@@ -1363,7 +1660,7 @@
           "std",
           "blank"
         ],
-        "nixpkgs": "nixpkgs_5",
+        "nixpkgs": "nixpkgs_6",
         "paisano": "paisano",
         "paisano-tui": "paisano-tui",
         "terranix": [
@@ -1475,7 +1772,28 @@
     },
     "treefmt-nix_2": {
       "inputs": {
-        "nixpkgs": "nixpkgs_6"
+        "nixpkgs": [
+          "ocaml-flake",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1698438538,
+        "narHash": "sha256-AWxaKTDL3MtxaVTVU5lYBvSnlspOS0Fjt8GxBgnU0Do=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "5deb8dc125a9f83b65ca86cf0c8167c46593e0b1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "treefmt-nix_3": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_7"
       },
       "locked": {
         "lastModified": 1698438538,

--- a/flake.nix
+++ b/flake.nix
@@ -19,6 +19,9 @@
     nix-cargo-integration.url = "github:yusdacra/nix-cargo-integration";
     nix-cargo-integration.inputs.nixpkgs.follows = "nixpkgs";
     nix-cargo-integration.inputs.dream2nix.follows = "dream2nix_legacy";
+    ocaml-flake.url = "github:9glenda/ocaml-flake";
+    ocaml-flake.inputs.nixpkgs.follows = "nixpkgs";
+    ocaml-flake.inputs.treefmt-nix.follows = "treefmt-nix";
     pre-commit-hooks-nix.url = "github:cachix/pre-commit-hooks.nix";
     pre-commit-hooks-nix.inputs.nixpkgs.follows = "nixpkgs";
     proc-flake.url = "github:srid/proc-flake";
@@ -296,6 +299,25 @@
             ## Installation
 
             See the [readme](https://github.com/yusdacra/nix-cargo-integration#readme).
+          '';
+        };
+
+        ocaml-flake = {
+          title = "ocaml-flake";
+          baseUrl = "https://github.com/9glenda/ocaml-flake";
+          attributePath = [ "flakeModule" ];
+          intro = ''
+            [`ocaml-flake`](https://github.com/9glenda/ocaml-flake) uses [`opam-nix`](https://github.com/tweag/opam-nix) to build ocaml packages. The module structure is inspired by [`haskell-flake`](https://haskell.flake.page/).
+
+            Since the flake is fairly new future versions may introduce breaking changes.
+          '';
+          installation = ''
+            ## Installation
+            To initialize a new dune project using `ocaml-flake` simply run:
+            ```sh
+            nix flake init -t github:9glenda/ocaml-flake#simple
+            ```
+            This will set up a devshell and package for you.
           '';
         };
 

--- a/site/src/SUMMARY.md
+++ b/site/src/SUMMARY.md
@@ -29,6 +29,7 @@
     - [`hercules-ci-effects`](./options/hercules-ci-effects.md)
     - [`mission-control`](./options/mission-control.md)
     - [`nix-cargo-integration`](./options/nix-cargo-integration.md)
+    - [`ocaml-flake`](./options/ocaml-flake.md)
     - [`pre-commit-hooks.nix`](./options/pre-commit-hooks-nix.md)
     - [`proc-flake`](./options/proc-flake.md)
     - [`process-compose-flake`](./options/process-compose-flake.md)


### PR DESCRIPTION
I created [ocaml-flake](https://github.com/9glenda/ocaml-flake) because there is no ocaml integration for flake-parts available. 
The project is still in a early stage but already usable for building basic ocaml projects.