### PR TITLE
Add make-shell

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1277,6 +1277,21 @@
         "type": "indirect"
       }
     },
+    "make-shell": {
+      "locked": {
+        "lastModified": 1720023242,
+        "narHash": "sha256-+I7RjtgrsnqezUQQ1r3MwibXxlotpdGBwrv7R9trc3Q=",
+        "owner": "nicknovitski",
+        "repo": "make-shell",
+        "rev": "cb67e941268e7c6f1485fd48d4c6db85a6ad1005",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nicknovitski",
+        "repo": "make-shell",
+        "type": "github"
+      }
+    },
     "mirage-opam-overlays": {
       "flake": false,
       "locked": {
@@ -2140,6 +2155,7 @@
         "flake-parts": "flake-parts_6",
         "haskell-flake": "haskell-flake_3",
         "hercules-ci-effects": "hercules-ci-effects",
+        "make-shell": "make-shell",
         "mission-control": "mission-control",
         "nix-cargo-integration": "nix-cargo-integration",
         "nixpkgs": "nixpkgs_5",

--- a/flake.nix
+++ b/flake.nix
@@ -21,6 +21,7 @@
     ez-configs.inputs.nixpkgs-darwin.follows = "nixpkgs";
     haskell-flake.url = "github:srid/haskell-flake";
     hercules-ci-effects.url = "github:hercules-ci/hercules-ci-effects";
+    make-shell.url = "github:nicknovitski/make-shell";
     mission-control.url = "github:Platonic-Systems/mission-control";
     nix-cargo-integration.url = "github:yusdacra/nix-cargo-integration";
     nix-cargo-integration.inputs.nixpkgs.follows = "nixpkgs";
@@ -215,6 +216,47 @@
              - a mergeable `herculesCI` attribute; read by [Hercules CI](https://hercules-ci.com) and the [`hci`](https://docs.hercules-ci.com/hercules-ci-agent/hci/) command,
              - the [`hci-effects`](https://docs.hercules-ci.com/hercules-ci-effects/guide/import-or-pin/#_flakes_with_flake_parts) library as a module argument in `perSystem` / `withSystem`,
              - ready to go, configurable continuous deployment jobs
+          '';
+        };
+
+        make-shell = {
+          baseUrl = "https://github.com/nicknovitski/make-shell/blob/main";
+          attributePath = [ "flakeModules" "default" ];
+          intro = ''
+            Modules for mkShell!  Set `make-shells.<name>` attributes to create `devShells.<name>` and `checks.<name>-devshell` flake outputs.  Import and merge complex or shared modules!  Create and share new options!
+
+            For example:
+            ```nix
+            # aliases.nix
+            {
+              config,
+              lib,
+              pkgs,
+              ...
+            }: {
+              options.aliases = lib.mkOption {
+                type = lib.types.attrsOf lib.types.singleLineStr;
+                default = {};
+              };
+              config.packages = let
+                inherit (lib.attrsets) mapAttrsToList;
+                alias = name: command: (pkgs.writeShellScriptBin name \'\'exec ''${command} "$@"\'\') // {meta.description = "alias for `''${command}`";};
+              in
+                mapAttrsToList alias config.aliases;
+            }
+            ```
+            ```nix
+            # flake.nix
+            perSystem = {...}: {
+              make-shells.default = {
+                 imports = [./aliases.nix];
+                 aliases = {
+                   n = "nix";
+                   g = "git";
+                 };
+               };
+            };
+            ```
           '';
         };
 


### PR DESCRIPTION
`make-shell` is a (usually) drop-in replacement for `mkShell` which evaluates its parameter as a module, allowing imports, new options, all the rest.  As a flake module, it's a smaller, possibly worse version of devenv and devshell. 😅 .