### PR TITLE
Add `render.enable` and `render.output` options

### DIFF
--- a/render/render-module.nix
+++ b/render/render-module.nix
@@ -1,6 +1,7 @@
 top@{ config, inputs, lib, flake-parts-lib, ... }:
 let
   inherit (lib)
+    mkIf
     mkOption
     types
     concatMap
@@ -424,9 +425,20 @@ in
     {
       options = {
         render = {
+          enable = mkOption {
+            type = types.bool;
+            description = "Whether to install the rendered docs to `perSystem.packages`.";
+            default = true;
+            example = false;
+          };
           inputs = mkOption {
-            description = "Which modules to render.";
             type = types.attrsOf (types.submodule inputModule);
+            description = ''
+              Which modules to render.
+
+              The rendered docs are installed as `perSystem.packages.generated-docs-<name>`,
+              unless [`enable`](#opt-perSystem.render.enable) is set to false.
+            '';
           };
           officialFlakeInputs = mkOption {
             type = types.raw;
@@ -437,60 +449,74 @@ in
             '';
             readOnly = true;
           };
+          output = mkOption {
+            type = types.package;
+            description = ''
+              The generated-docs package.
+
+              Contains the rendered docs for all of [`inputs`](#opt-perSystem.render.inputs),
+              along with a `menu.md` summary file.
+
+              Installed as `perSystem.packages.generated-docs`,
+              unless [`enable`](#opt-perSystem.render.enable) is set to false.
+            '';
+            readOnly = true;
+          };
         };
       };
       config = {
-        packages = lib.mapAttrs' (name: inputCfg: { name = "generated-docs-${name}"; value = inputCfg.rendered; }) cfg.inputs // {
-          generated-docs =
-            pkgs.runCommand "generated-docs"
-              {
-                passthru = {
-                  inherit config;
-                  inherit eval;
-                  # This won't be in sync with the actual nixosOptionsDoc
-                  # invocations, but it's useful for troubleshooting.
-                  allOptionsPerhaps = (pkgs.nixosOptionsDoc {
-                    options = opts;
-                  }).optionsNix;
-                };
-                passAsFile = [ "menu" ];
-                menu =
-                  let
-                    inputsToMenuItems =
-                      inputs:
-                      lib.concatStringsSep
-                        "\n"
-                        (lib.filter
-                          (x: x != "")
-                          (lib.mapAttrsToList
-                            (name: inputCfg:
-                            lib.optionalString inputCfg.menu.enable
-                              "    - [${inputCfg.menu.title}](options/${name}.md)"
-                            )
-                            inputs
-                          )
-                        );
-                    normalInputs = lib.filterAttrs (name: inputCfg: !inputCfg.archived) cfg.inputs;
-                    archivedInputs = lib.filterAttrs (name: inputCfg: inputCfg.archived) cfg.inputs;
-                  in
-                  ''
-                    ${inputsToMenuItems normalInputs}
-                      - [Archived]()
-                    ${inputsToMenuItems archivedInputs}
-                  '';
-              }
+        packages = mkIf cfg.enable (
+          lib.mapAttrs' (name: inputCfg: { name = "generated-docs-${name}"; value = inputCfg.rendered; }) cfg.inputs
+          // { generated-docs = cfg.output; }
+        );
+        render.output = pkgs.runCommand "generated-docs"
+          {
+            passthru = {
+              inherit config;
+              inherit eval;
+              # This won't be in sync with the actual nixosOptionsDoc
+              # invocations, but it's useful for troubleshooting.
+              allOptionsPerhaps = (pkgs.nixosOptionsDoc {
+                options = opts;
+              }).optionsNix;
+            };
+            passAsFile = [ "menu" ];
+            menu =
+              let
+                inputsToMenuItems =
+                  inputs:
+                  lib.concatStringsSep
+                    "\n"
+                    (lib.filter
+                      (x: x != "")
+                      (lib.mapAttrsToList
+                        (name: inputCfg:
+                        lib.optionalString inputCfg.menu.enable
+                          "    - [${inputCfg.menu.title}](options/${name}.md)"
+                        )
+                        inputs
+                      )
+                    );
+                normalInputs = lib.filterAttrs (name: inputCfg: !inputCfg.archived) cfg.inputs;
+                archivedInputs = lib.filterAttrs (name: inputCfg: inputCfg.archived) cfg.inputs;
+              in
               ''
-                mkdir $out
-                ${lib.concatStringsSep "\n"
-                  (lib.mapAttrsToList
-                    (name: inputCfg: ''
-                      cp ${inputCfg.rendered.file} $out/${name}.html
-                    '')
-                    cfg.inputs)
-                }
-                cp $menuPath $out/menu.md
+                ${inputsToMenuItems normalInputs}
+                  - [Archived]()
+                ${inputsToMenuItems archivedInputs}
               '';
-        };
+          }
+          ''
+            mkdir $out
+            ${lib.concatStringsSep "\n"
+              (lib.mapAttrsToList
+                (name: inputCfg: ''
+                  cp ${inputCfg.rendered.file} $out/${name}.html
+                '')
+                cfg.inputs)
+            }
+            cp $menuPath $out/menu.md
+          '';
       };
     });
 }


### PR DESCRIPTION
Allow downstream users to use the render module, without adding packages to `perSystem.packages`.

### Motivation
In nixvim, we already have a MDBook based documentation site, similar to the flake.parts website.

We'd like to add some pages documenting flake-parts modules, so the `render` module would be useful to avoid re-implement things like `evalWith` ourselves.

However we don't need/want to add the `generated-docs` packages to our flake outputs. Instead, we'd iterate over `perSystem.render.inputs` ourselves, perhaps adding relevant derivations as `passthru` attrs on our main docs package.
