### PR TITLE
flake: Un-override terranix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2605,16 +2605,15 @@
         "terranix-examples": []
       },
       "locked": {
-        "lastModified": 1745514661,
-        "narHash": "sha256-0r9P5U3gTwH49YiZ0IIuFr0E+yt/WP3LvAZiPFwZT5A=",
-        "owner": "roberth",
+        "lastModified": 1745593106,
+        "narHash": "sha256-S06+W67u/13zT0Ltse+dPCs/vkiM7Rt9c9eNWZAx/Y4=",
+        "owner": "terranix",
         "repo": "terranix",
-        "rev": "a157f4c3941f8d08cb2d0a0cafcc867eaddb46b3",
+        "rev": "b860913b83d56ba46f6045a7baed2964bc749fc3",
         "type": "github"
       },
       "original": {
-        "owner": "roberth",
-        "ref": "fix-docs-eval",
+        "owner": "terranix",
         "repo": "terranix",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -63,9 +63,7 @@
     rust-flake.url = "github:juspay/rust-flake";
     std.url = "github:divnix/std";
     std.inputs.nixpkgs.follows = "nixpkgs";
-    # https://github.com/terranix/terranix/pull/121
-    terranix.url = "github:roberth/terranix/fix-docs-eval";
-    # terranix.url = "github:terranix/terranix";
+    terranix.url = "github:terranix/terranix";
     terranix.inputs.bats-assert.follows = "";
     terranix.inputs.bats-support.follows = "";
     terranix.inputs.flake-parts.follows = "flake-parts";


### PR DESCRIPTION
Flake lock file updates:

• Updated input 'terranix':
    'github:roberth/terranix/a157f4c3941f8d08cb2d0a0cafcc867eaddb46b3?narHash=sha256-0r9P5U3gTwH49YiZ0IIuFr0E%2Byt/WP3LvAZiPFwZT5A%3D' (2025-04-24)
  → 'github:terranix/terranix/b860913b83d56ba46f6045a7baed2964bc749fc3?narHash=sha256-S06%2BW67u/13zT0Ltse%2BdPCs/vkiM7Rt9c9eNWZAx/Y4%3D' (2025-04-25)