### PR TITLE
home-manager: Fix naming (home-manager → Home Manager)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -319,10 +319,10 @@
           home-manager = {
             baseUrl = "https://github.com/nix-community/home-manager/blob/master";
             intro = ''
-              [`home-manager`](https://nix-community.github.io/home-manager/) is a tool for managing home directories and user profiles using Nix.
+              [Home Manager](https://nix-community.github.io/home-manager/) is a tool for managing home directories and user profiles using Nix.
               To quote, this includes programs, configuration files, environment variables and, well… arbitrary files.
 
-              For simple setups where the home manager flake outputs are defined in one file, you may not need to import this module.
+              For simple setups where the Home Manager flake outputs are defined in one file, you may not need to import this module.
 
               For more details and an example, see [Home Manager: flake-parts module](https://nix-community.github.io/home-manager/index.xhtml#sec-flakes-flake-parts-module).
             '';


### PR DESCRIPTION
As per upstream preference. See https://github.com/nix-community/home-manager/pull/6384.


Follow up to #1364