### PR TITLE
style: config binding is only ever the top-level one

### DIFF
--- a/core-modules.nix
+++ b/core-modules.nix
@@ -14,7 +14,7 @@
       inputs = perSystemArgs.config.render.officialFlakeInputs;
 
       commonExtras =
-        { lib, config, ... }:
+        commonExtrasArgs@{ lib, ... }:
         let
           inherit (lib) mkOption types;
         in
@@ -31,18 +31,18 @@
               description = ''
                 The path to the source file, relative to the flake's root.
               '';
-              default = "/extras/${config.extraName}.nix";
+              default = "/extras/${commonExtrasArgs.config.extraName}.nix";
             };
           };
           config = {
             _module.args.name = lib.mkForce "flake-parts";
-            title = "flake-parts.${config.extraName}";
-            baseUrl = "https://github.com/hercules-ci/flake-parts/blob/main${config.sourceSubpath}";
+            title = "flake-parts.${commonExtrasArgs.config.extraName}";
+            baseUrl = "https://github.com/hercules-ci/flake-parts/blob/main${commonExtrasArgs.config.sourceSubpath}";
             flake = inputs.flake-parts;
-            getModules = f: [ f.flakeModules.${config.extraName} ];
+            getModules = f: [ f.flakeModules.${commonExtrasArgs.config.extraName} ];
             attributePath = [
               "flakeModules"
-              config.extraName
+              commonExtrasArgs.config.extraName
             ];
             installationDeclareInput = false;
             filterTransformOptions =
@@ -53,7 +53,7 @@
                 ...
               }:
               let
-                sourcePathStr = toString sourcePath + config.sourceSubpath;
+                sourcePathStr = toString sourcePath + commonExtrasArgs.config.sourceSubpath;
               in
               opt:
               let

--- a/core-modules.nix
+++ b/core-modules.nix
@@ -9,9 +9,9 @@
 { ... }:
 {
   config.perSystem =
-    { config, ... }:
+    perSystemArgs:
     let
-      inputs = config.render.officialFlakeInputs;
+      inputs = perSystemArgs.config.render.officialFlakeInputs;
 
       commonExtras =
         { lib, config, ... }:

--- a/deploy-module.nix
+++ b/deploy-module.nix
@@ -5,13 +5,12 @@
 {
   herculesCI = herculesCI: {
     onPush.default.outputs.effects.netlifyDeploy = withSystem "x86_64-linux" (
-      {
-        config,
+      perSystemArgs@{
         hci-effects,
         ...
       }:
       hci-effects.netlifyDeploy {
-        content = config.packages.default;
+        content = perSystemArgs.config.packages.default;
         secretName = "default-netlify";
         siteId = "29a153b1-3698-433c-bc73-62415efb8117";
         productionDeployment = herculesCI.config.repo.branch == "main";

--- a/dev-module.nix
+++ b/dev-module.nix
@@ -5,8 +5,7 @@
   ];
 
   perSystem =
-    {
-      config,
+    perSystemArgs@{
       pkgs,
       ...
     }:
@@ -25,7 +24,7 @@
         shellHook = ''
           # Configure this repo to ignore certain revisions in git blame
           git config blame.ignoreRevsFile ${ignoreRevsFile}
-          ${config.pre-commit.shellHook}
+          ${perSystemArgs.config.pre-commit.shellHook}
         '';
       };
 

--- a/render/render-module.nix
+++ b/render/render-module.nix
@@ -143,7 +143,7 @@ in
           opt // { inherit declarations; };
 
       inputModule =
-        { config, name, ... }:
+        inputArgs@{ name, ... }:
         {
           options = {
             flake = mkOption {
@@ -160,7 +160,7 @@ in
               description = ''
                 Source path in which the modules are contained.
               '';
-              default = config.flake.outPath;
+              default = inputArgs.config.flake.outPath;
               defaultText = lib.literalExpression "config.flake.outPath";
             };
 
@@ -181,7 +181,7 @@ in
                 # This only works for github for now, but we can set a non-default
                 # value in the list just fine.
                 let
-                  match = builtins.match "https://github.com/([^/]*)/([^/]*)/blob/([^/]*)" config.baseUrl;
+                  match = builtins.match "https://github.com/([^/]*)/([^/]*)/blob/([^/]*)" inputArgs.config.baseUrl;
                   owner = lib.elemAt match 0;
                   repo = lib.elemAt match 1;
                   # branch = lib.elemAt match 2; # ignored for now because they're all default branches
@@ -189,7 +189,7 @@ in
                 if match != null then
                   "github:${owner}/${repo}"
                 else
-                  throw "Couldn't figure out flakeref for ${name}: ${config.baseUrl}";
+                  throw "Couldn't figure out flakeref for ${name}: ${inputArgs.config.baseUrl}";
               defaultText = lib.literalMD ''
                 Determined from `config.baseUrl`.
               '';
@@ -215,7 +215,7 @@ in
                 Stuff between the title and the options.
               '';
               default = ''
-                ${lib.optionalString config.archived ''
+                ${lib.optionalString inputArgs.config.archived ''
                   <div class="warning">
 
                   This module has been archived because it appears to be unmaintained.
@@ -223,9 +223,9 @@ in
                   </div>
                 ''}
 
-                ${config.intro}
+                ${inputArgs.config.intro}
 
-                ${config.installation}
+                ${inputArgs.config.installation}
 
               '';
               defaultText = lib.literalMD "`intro` followed by `installation`";
@@ -255,12 +255,12 @@ in
                 ## Installation
 
                 ${
-                  if config.installationDeclareInput then
+                  if inputArgs.config.installationDeclareInput then
                     ''
                       To use these options, add to your flake inputs:
 
                       ```nix
-                      ${config.sourceName}.url = "${config.flakeRef}";
+                      ${inputArgs.config.sourceName}.url = "${inputArgs.config.flakeRef}";
                       ```
 
                       and inside the `mkFlake`:
@@ -275,10 +275,10 @@ in
                 imports = [
                   ${lib.strings.concatMapStringsSep "\n  " (
                     attributePath:
-                    "inputs.${config.sourceName}.${
+                    "inputs.${inputArgs.config.sourceName}.${
                       lib.concatMapStringsSep "." lib.strings.escapeNixIdentifier attributePath
                     }"
-                  ) config.attributePaths}
+                  ) inputArgs.config.attributePaths}
                 ];
                 ```
 
@@ -310,7 +310,7 @@ in
               default =
                 flake:
                 (builtins.addErrorContext "while getting modules for input '${name}'" (
-                  map (p: lib.getAttrFromPath p flake) config.attributePaths
+                  map (p: lib.getAttrFromPath p flake) inputArgs.config.attributePaths
                 ));
               defaultText = lib.literalMD "Derived from `config.attributePaths`, `<name>`";
             };
@@ -327,7 +327,7 @@ in
               description = ''
                 Flake output attribute path to import.
               '';
-              default = [ config.attributePath ];
+              default = [ inputArgs.config.attributePath ];
               example = [
                 [
                   "flakeModules"
@@ -418,7 +418,7 @@ in
                 description = ''
                   Title of the menu entry.
                 '';
-                default = config.title;
+                default = inputArgs.config.title;
               };
               enable = mkOption {
                 type = types.bool;
@@ -434,57 +434,59 @@ in
           config = {
             _nixosOptionsDoc = pkgs.nixosOptionsDoc {
               options =
-                if config.separateEval then
+                if inputArgs.config.separateEval then
                   (evalWith {
-                    modules = config.getModules config.flake;
-                    extraInputs = config.extraInputs;
+                    modules = inputArgs.config.getModules inputArgs.config.flake;
+                    extraInputs = inputArgs.config.extraInputs;
                   }).options
                 else
                   opts;
               documentType = "none";
-              transformOptions = config.filterTransformOptions {
-                inherit (config) sourceName baseUrl sourcePath;
+              transformOptions = inputArgs.config.filterTransformOptions {
+                inherit (inputArgs.config) sourceName baseUrl sourcePath;
                 inherit coreOptDecls;
               };
-              warningsAreErrors = config.warningsAreErrors;
+              warningsAreErrors = inputArgs.config.warningsAreErrors;
             };
             rendered =
               let
-                checkEmpty = lib.throwIf (config.isEmpty != (config._nixosOptionsDoc.optionsNix == { })) (
-                  if
-                    config.isEmpty # ie expected
-                  then
-                    "The input ${name} now has options. Please remove `isEmpty = true;` from the input."
-                  else
-                    ''
-                      Did not find any options to render for ${name}.
+                checkEmpty =
+                  lib.throwIf (inputArgs.config.isEmpty != (inputArgs.config._nixosOptionsDoc.optionsNix == { }))
+                    (
+                      if
+                        inputArgs.config.isEmpty # ie expected
+                      then
+                        "The input ${name} now has options. Please remove `isEmpty = true;` from the input."
+                      else
+                        ''
+                          Did not find any options to render for ${name}.
 
-                      If this is intentional, set `isEmpty = true;` on the input. Otherwise, set `_file` to a subpath of the containing flake.
+                          If this is intentional, set `isEmpty = true;` on the input. Otherwise, set `_file` to a subpath of the containing flake.
 
-                      Otherwise, the two most likely causes are:
-                      - All options are in `config.perSystem` instead of `options.perSystem`
-                      - The module is "anonymous", i.e. the module system does not know in which
-                        file the options are declared.
+                          Otherwise, the two most likely causes are:
+                          - All options are in `config.perSystem` instead of `options.perSystem`
+                          - The module is "anonymous", i.e. the module system does not know in which
+                            file the options are declared.
 
-                      In the latter case, make sure that the module isn't just specified in a file,
-                      but loaded in such a way that the module system is aware of the file name.
-                      e.g.
-                        change: flakeModules.default = import ./flake-module.nix;
-                            to: flakeModules.default = ./flake-module.nix;
-                      or
-                        change: flakeModule = { ... }: { foo = true; };
-                            to: flakeModule = { ... }: { _file = __curPos.file; foo = true; };
-                    ''
-                );
+                          In the latter case, make sure that the module isn't just specified in a file,
+                          but loaded in such a way that the module system is aware of the file name.
+                          e.g.
+                            change: flakeModules.default = import ./flake-module.nix;
+                                to: flakeModules.default = ./flake-module.nix;
+                          or
+                            change: flakeModule = { ... }: { foo = true; };
+                                to: flakeModule = { ... }: { _file = __curPos.file; foo = true; };
+                        ''
+                    );
               in
 
               checkEmpty pkgs.stdenv.mkDerivation (finalAttrs: {
-                name = "option-doc-${config.sourceName}";
+                name = "option-doc-${inputArgs.config.sourceName}";
                 nativeBuildInputs = [
                   pkgs.libxslt.bin
                   pkgs.pandoc
                 ];
-                optionsDoc = config._nixosOptionsDoc.optionsCommonMark.overrideAttrs {
+                optionsDoc = inputArgs.config._nixosOptionsDoc.optionsCommonMark.overrideAttrs {
                   extraArgs = [
                     "--anchor-prefix"
                     "opt-"
@@ -492,7 +494,7 @@ in
                     "legacy"
                   ];
                 };
-                inherit (config) title preface;
+                inherit (inputArgs.config) title preface;
                 passAsFile = [ "preface" ];
                 buildCommand = ''
                   mkdir $out
@@ -508,12 +510,12 @@ in
                   EOF
                   # cat -n $out/options.md | grep caddy
                   # set -x
-                  ${lib.optionalString (config.fixupAnchorsBaseUrl != null) ''
-                    sed -i 's|(\(\\#[^o)][^p)][^t)][^-)][^)]*\))|(${config.fixupAnchorsBaseUrl}\1)|g' $out/options.md
+                  ${lib.optionalString (inputArgs.config.fixupAnchorsBaseUrl != null) ''
+                    sed -i 's|(\(\\#[^o)][^p)][^t)][^-)][^)]*\))|(${inputArgs.config.fixupAnchorsBaseUrl}\1)|g' $out/options.md
                   ''}
                 '';
                 passthru.file = finalAttrs.finalPackage + "/options.md";
-                passthru.config = config;
+                passthru.config = inputArgs.config;
               });
           };
         };

--- a/render/render-module.nix
+++ b/render/render-module.nix
@@ -39,36 +39,33 @@ in
       fixups =
         { lib, flake-parts-lib, ... }:
         {
-          options.perSystem = flake-parts-lib.mkPerSystemOption (
-            { config, ... }:
-            {
-              config = {
-                _module.args.pkgs = pkgsStub // {
-                  _type = "pkgs";
-                  inherit lib;
-                  postgresql = {
-                    inherit (pkgs.postgresql) pkgs;
-                  };
-                  # no-op
-                  appendOverlays = _ignored: config._module.args.pkgs;
-                  formats = lib.mapAttrs (
-                    formatName: formatFn: formatArgs:
-                    let
-                      result = formatFn formatArgs;
-                      stubs = lib.mapAttrs (
-                        name: _:
-                        throw "The attribute `(pkgs.formats.${lib.strings.escapeNixIdentifier formatName} x).${lib.strings.escapeNixIdentifier name}` is not supported during documentation generation. Please check with `--show-trace` to see which option leads to this `${lib.strings.escapeNixIdentifier name}` reference. Often it can be cut short with a `defaultText` argument to `lib.mkOption`, or by escaping an option `example` using `lib.literalExpression`."
-                      ) result;
-                    in
-                    stubs
-                    // {
-                      inherit (result) type;
-                    }
-                  ) pkgs.formats;
+          options.perSystem = flake-parts-lib.mkPerSystemOption (fixupsArgs: {
+            config = {
+              _module.args.pkgs = pkgsStub // {
+                _type = "pkgs";
+                inherit lib;
+                postgresql = {
+                  inherit (pkgs.postgresql) pkgs;
                 };
+                # no-op
+                appendOverlays = _ignored: fixupsArgs.config._module.args.pkgs;
+                formats = lib.mapAttrs (
+                  formatName: formatFn: formatArgs:
+                  let
+                    result = formatFn formatArgs;
+                    stubs = lib.mapAttrs (
+                      name: _:
+                      throw "The attribute `(pkgs.formats.${lib.strings.escapeNixIdentifier formatName} x).${lib.strings.escapeNixIdentifier name}` is not supported during documentation generation. Please check with `--show-trace` to see which option leads to this `${lib.strings.escapeNixIdentifier name}` reference. Often it can be cut short with a `defaultText` argument to `lib.mkOption`, or by escaping an option `example` using `lib.literalExpression`."
+                    ) result;
+                  in
+                  stubs
+                  // {
+                    inherit (result) type;
+                  }
+                ) pkgs.formats;
               };
-            }
-          );
+            };
+          });
         };
 
       eval = evalWith {

--- a/render/render-module.nix
+++ b/render/render-module.nix
@@ -25,15 +25,14 @@ let
 in
 {
   options.perSystem = flake-parts-lib.mkPerSystemOption (
-    {
-      config,
+    perSystemArgs@{
       pkgs,
       lib,
       ...
     }:
     let
-      cfg = config.render;
-      inputs = config.render.officialFlakeInputs // top.inputs;
+      cfg = perSystemArgs.config.render;
+      inputs = perSystemArgs.config.render.officialFlakeInputs // top.inputs;
 
       pkgsStub = lib.mapAttrs failPkgAttr pkgs;
 
@@ -105,7 +104,7 @@ in
 
       opts = eval.options;
 
-      coreOptDecls = config.render.inputs.flake-parts._nixosOptionsDoc.optionsNix;
+      coreOptDecls = perSystemArgs.config.render.inputs.flake-parts._nixosOptionsDoc.optionsNix;
 
       filterTransformOptions =
         {
@@ -576,7 +575,7 @@ in
           pkgs.runCommand "generated-docs"
             {
               passthru = {
-                inherit config;
+                inherit (perSystemArgs) config;
                 inherit eval;
                 # This won't be in sync with the actual nixosOptionsDoc
                 # invocations, but it's useful for troubleshooting.

--- a/site/site-module.nix
+++ b/site/site-module.nix
@@ -1,8 +1,7 @@
 { inputs, flake-parts-lib, ... }:
 {
   options.perSystem = flake-parts-lib.mkPerSystemOption (
-    {
-      config,
+    perSystemArgs@{
       pkgs,
       ...
     }:
@@ -18,11 +17,11 @@
           {
             nativeBuildInputs = [ pkgs.lychee ];
             SSL_CERT_FILE = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
-            site = config.packages.default;
+            site = perSystemArgs.config.packages.default;
             config = (pkgs.formats.toml { }).generate "lychee.toml" {
               include_fragments = "full";
               remap = [
-                "https://flake.parts file://${config.packages.default}"
+                "https://flake.parts file://${perSystemArgs.config.packages.default}"
               ];
             };
           }
@@ -61,11 +60,11 @@
             } <${inputs.flake-parts + "/README.md"} >src/README.md
 
             mkdir -p src/options
-            for f in ${config.packages.generated-docs}/*.html; do
+            for f in ${perSystemArgs.config.packages.generated-docs}/*.html; do
               cp "$f" "src/options/$(basename "$f" .html).md"
             done
             sed -e 's/<!-- module list will be concatenated to the end -->//g' -i src/SUMMARY.md
-            cat ${config.packages.generated-docs}/menu.md >> src/SUMMARY.md
+            cat ${perSystemArgs.config.packages.generated-docs}/menu.md >> src/SUMMARY.md
             mdbook build --dest-dir $out
 
             # mdbook hashes asset filenames but doesn't rewrite url() in additional CSS
@@ -91,7 +90,7 @@
           openApp = {
             type = "app";
             program = "${pkgs.writeShellScript "open-manual" ''
-              path="${config.packages.default}/index.html"
+              path="${perSystemArgs.config.packages.default}/index.html"
               if ! ${opener} "$path"; then
                 echo "Failed to open manual with ${opener}. Manual is located at:"
                 echo "$path"


### PR DESCRIPTION
Look, I'm not trying to force my style on anyone. Just found this particular pattern to be easier to navigate, because `config` is only ever the top-level one and any nested module scope `config` must be accessed using `perSystemArgs.config` or similar. This obviates the question of "wait, which `config` is this" that I find myself otherwise asking too often.

This pattern also eliminates the risk of using a `config` binding that is different than the one we had intended to use.

So, overall, at the cost of some expressions getting longer, I think this is a worthwhile tradeoff.

What do you think?

In my `infra` I've actually been using `psArgs` instead of `perSystemArgs`, so if you prefer that I really don't mind. I wanted to be kind to the reader here by being totally clear.

Or perhaps you can think of a more appropriate suffix than `Args` 🤷‍♂️

Anyway, I was careful to do this incrementally, one commit per scope, and running `nix build` (or `direnv reload`) each time.
I did not test the Hercules CI change.
