### PR TITLE
Add Prelude to community modules

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2957,6 +2957,32 @@
         "type": "github"
       }
     },
+    "prelude": {
+      "inputs": {
+        "flake-parts": [
+          "flake-parts"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "treefmt-nix": [
+          "treefmt-nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1784725586,
+        "narHash": "sha256-srAfht5eD3egv+EoC5BMJYkaQZoIqZYIRl/dHY6du/Q=",
+        "owner": "darkmatter",
+        "repo": "prelude",
+        "rev": "fe66e24c40b48494d69bb43d8d65b757c251732a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "darkmatter",
+        "repo": "prelude",
+        "type": "github"
+      }
+    },
     "proc-flake": {
       "locked": {
         "lastModified": 1713493374,
@@ -3113,6 +3139,7 @@
         "nixpkgs": "nixpkgs_4",
         "ocaml-flake": "ocaml-flake",
         "pkgs-by-name-for-flake-parts": "pkgs-by-name-for-flake-parts",
+        "prelude": "prelude",
         "proc-flake": "proc-flake",
         "process-compose-flake": "process-compose-flake",
         "pydev": "pydev",

--- a/flake.nix
+++ b/flake.nix
@@ -81,6 +81,10 @@
     git-hooks-nix.url = "github:cachix/git-hooks.nix";
     git-hooks-nix.inputs.nixpkgs.follows = "nixpkgs";
     pkgs-by-name-for-flake-parts.url = "github:drupol/pkgs-by-name-for-flake-parts";
+    prelude.url = "github:darkmatter/prelude";
+    prelude.inputs.flake-parts.follows = "flake-parts";
+    prelude.inputs.nixpkgs.follows = "nixpkgs";
+    prelude.inputs.treefmt-nix.follows = "treefmt-nix";
     proc-flake.url = "github:srid/proc-flake";
     process-compose-flake.url = "github:Platonic-systems/process-compose-flake";
     pydev.url = "github:oceansprint/pydev";
@@ -738,6 +742,22 @@
                 };
               }
               ```
+            '';
+          };
+
+          prelude = {
+            title = "Prelude";
+            baseUrl = "https://github.com/darkmatter/prelude/blob/main";
+            attributePath = [
+              "flakeModules"
+              "default"
+            ];
+            intro = ''
+              [`Prelude`](https://github.com/darkmatter/prelude) is a devshell UI suite for flake-parts projects.
+              It provides a configurable welcome banner and interactive command menu for project workflows,
+              so contributors can discover the available commands directly from `nix develop` or `nix run .#menu`.
+
+              See also the [Prelude configuration guide](https://github.com/darkmatter/prelude/blob/main/docs/configuration.md).
             '';
           };
 


### PR DESCRIPTION
## Summary
- add [darkmatter/prelude](https://github.com/darkmatter/prelude) to the flake.parts community module docs inputs
- render the Prelude flake-parts module from flakeModules.default
- include a short description and link to its configuration guide

## Validation
- nix build .work/flake.parts-website#generated-docs-prelude --no-link