### PR TITLE
Add guide: source `pkgs` and `lib` without flake inputs

### DIFF
--- a/site/src/SUMMARY.md
+++ b/site/src/SUMMARY.md
@@ -10,6 +10,7 @@
   - [Explore and debug option values](./debug.md)
   - [Define a Module in a Separate File](./define-module-in-separate-file.md)
   - [Define Custom Flake Attribute](./define-custom-flake-attribute.md)
+  - [Source `pkgs` and `lib` Without Flake Inputs](./without-flake-inputs.md)
   - [Generate Documentation](./generate-documentation.md)
   - [Dogfood a Reusable Flake Module](./dogfood-a-reusable-module.md)
 - [Explanation]()

--- a/site/src/module-arguments.md
+++ b/site/src/module-arguments.md
@@ -36,7 +36,7 @@ See the [Nixpkgs manual](https://nixos.org/manual/nixpkgs/unstable/#id-1.4) for 
 
 For the `nixpkgs-lib` input, you may specify a flake that only contains `lib`, or a whole Nixpkgs flake. By default, just `lib` gives you slightly faster shell tab completion as of writing.
 
-To promote modularity and not create unnecessary, "strange" dependency constraints on `lib`, you are recommended not to override it. You may select a different version of it using Flake [`follows`](https://nix.dev/manual/nix/latest/command-ref/new-cli/nix3-flake.html#flake-inputs).
+To promote modularity and not create unnecessary, "strange" dependency constraints on `lib`, you are recommended not to override it. You may select a different version of it using Flake [`follows`](https://nix.dev/manual/nix/latest/command-ref/new-cli/nix3-flake.html#flake-inputs), or, when the version you want is not a flake input, as described in [Source `pkgs` and `lib` Without Flake Inputs](./without-flake-inputs.md#choosing-lib).
 
 ## More
 
@@ -111,7 +111,7 @@ Enter the scope of a system. Example:
 
 Default: `inputs.nixpkgs.legacyPackages.${system}`.
 
-Set via `config._module.args.pkgs`.
+Set via `config._module.args.pkgs`. This is also how you source Nixpkgs from something other than a flake input, such as an npins pin; see [Source `pkgs` and `lib` Without Flake Inputs](./without-flake-inputs.md).
 
 Example:
 

--- a/site/src/without-flake-inputs.md
+++ b/site/src/without-flake-inputs.md
@@ -1,0 +1,136 @@
+# Source `pkgs` and `lib` Without Flake Inputs
+
+flake-parts reads Nixpkgs from a flake input by default, but it does not require one.
+If your dependencies are pinned by [npins](https://github.com/andir/npins), [niv](https://github.com/nmattia/niv), or a hand-written `fetchTarball`, you can point flake-parts at those pins instead, whether or not the project has a `flake.nix` at all.
+
+## Choosing `pkgs`
+
+The `pkgs` argument in `perSystem` is a module argument, so you define it like any other:
+
+```nix
+perSystem = { system, ... }: {
+  _module.args.pkgs = import sources.nixpkgs { inherit system; };
+};
+```
+
+flake-parts' own definition is `inputs'.nixpkgs.legacyPackages.${system}`, wrapped in [`lib.mkOptionDefault`](https://nixos.org/manual/nixpkgs/unstable/#module-system-lib-mkOptionDefault).
+A plain definition therefore wins on its own; you do not need `lib.mkForce`.
+
+That default is also never forced when you override it, so the flake does not need a `nixpkgs` input in the first place:
+
+```nix
+{
+  # No `nixpkgs` input; the pin lives in `npins/sources.json`.
+  inputs.flake-parts.url = "github:hercules-ci/flake-parts";
+
+  outputs = inputs@{ flake-parts, ... }:
+    let sources = import ./npins;
+    in flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = [ "x86_64-linux" ];
+      perSystem = { system, pkgs, ... }: {
+        _module.args.pkgs = import sources.nixpkgs { inherit system; };
+
+        packages.default = pkgs.hello;
+      };
+    };
+}
+```
+
+`sources` is whatever your pinning tool returns; npins, niv and a plain `fetchTarball` are interchangeable here.
+Because you call `import` yourself, this is also where Nixpkgs configuration goes, such as `config.allowUnfree = true` or an `overlays` list.
+
+## Choosing `lib`
+
+`lib` does not come from your `pkgs`. It comes from flake-parts' own `nixpkgs-lib` input, and as [Module Arguments](module-arguments.md#lib) explains, you are recommended not to override it.
+
+When you do want the two to agree, and you have a `flake.nix`, use [`follows`](https://nix.dev/manual/nix/latest/command-ref/new-cli/nix3-flake.html#flake-inputs):
+
+```nix
+inputs.flake-parts.url = "github:hercules-ci/flake-parts";
+inputs.flake-parts.inputs.nixpkgs-lib.follows = "nixpkgs";
+```
+
+Without a `flake.nix` there is no `follows`. [flake-compat](https://git.lix.systems/lix-project/flake-compat) evaluates flake-parts' `flake.nix` for you, and with the input override support from [flake-compat pull request 87](https://git.lix.systems/lix-project/flake-compat/pulls/87) it can substitute `nixpkgs-lib` as well:
+
+```nix
+let
+  sources = import ./npins;
+
+  flake-compat = import sources.flake-compat;
+
+  flake-parts = (flake-compat { src = sources.flake-parts; }).overrideInputs {
+    nixpkgs-lib = sources.nixpkgs;
+  };
+in
+flake-parts.outputs.lib.mkFlake # ...
+```
+
+`overrideInputs` is not part of a released flake-compat yet, so until that pull request is merged, pin the branch it comes from.
+
+## What Does Not Carry Over
+
+The `inputs'` and `self'` module arguments are flake-only.
+[`modules/perSystem.nix`](https://github.com/hercules-ci/flake-parts/blob/main/modules/perSystem.nix) builds `inputs'` by walking `self.inputs` and throws for any entry whose `_type` is not `"flake"`.
+Two consequences:
+
+- A pin from npins is a store path, not a flake, so it cannot be reached through `inputs'`.
+- Only `self.inputs` is consulted. Adding an entry to the `inputs` you pass to `mkFlake` does not make it appear in `inputs'`.
+
+Non-flake sources reach your modules through the module system instead.
+Top-level modules can also take them through `mkFlake`'s `specialArgs`, but `_module.args` works in both scopes:
+
+```nix
+{
+  _module.args.sources = sources;
+  perSystem._module.args.sources = sources;
+}
+```
+
+For the wider picture, see [Extend beyond Flakes](https://github.com/hercules-ci/flake-parts/issues/329).
+
+## Complete Example
+
+A project with no `flake.nix`, pinned entirely by npins:
+
+```console
+$ npins init --bare
+$ npins add --name nixpkgs github NixOS nixpkgs --branch nixos-unstable
+$ npins add --name flake-parts github hercules-ci flake-parts --branch main
+# The pull request branch, until `overrideInputs` is merged into flake-compat.
+$ npins add --name flake-compat git https://git.lix.systems/kiaragrouwstra/flake-compat --branch override-inputs
+```
+
+`default.nix`:
+
+```nix
+let
+  sources = import ./npins;
+
+  flake-compat = import sources.flake-compat;
+
+  # flake-parts, with its own `nixpkgs-lib` input replaced by our pin.
+  flake-parts = (flake-compat { src = sources.flake-parts; }).overrideInputs {
+    nixpkgs-lib = sources.nixpkgs;
+  };
+
+  # flake-parts writes flake outputs, so it needs a `self`. Without a
+  # `flake.nix` there is nothing to produce one, so make it by hand.
+  self = {
+    _type = "flake";
+    outPath = ./.;
+    inputs = { };
+  };
+in
+flake-parts.outputs.lib.mkFlake { inputs = { inherit self; }; inherit self; } {
+  systems = [ "x86_64-linux" ];
+  perSystem = { system, pkgs, ... }: {
+    _module.args.pkgs = import sources.nixpkgs { inherit system; };
+
+    packages.default = pkgs.hello;
+  };
+}
+```
+
+```console
+$ nix-build -A packages.x86_64-linux.default
+```


### PR DESCRIPTION
Adds a Guide page, "Source `pkgs` and `lib` Without Flake Inputs", plus two cross-references from "Module Arguments".

## Why

It is a fairly common belief that flake-parts requires flake inputs to manage the `nixpkgs` pin, and that consuming it from npins-managed code needs workarounds ([nixops4#113](https://github.com/nixops4/nixops4/issues/113#issuecomment-3311004867) is one instance; the `fediversity` repo carried an `import-flake` shim that spliced nixpkgs into both `inputs` and `self.inputs`).

That belief is wrong, but nothing says so. `perSystem._module.args.pkgs` is the supported injection point, and it works today with no patch to flake-parts. The only place it appears in the docs is `template/unfree/flake.nix`, framed as an unfree-config trick rather than as the way to choose Nixpkgs; `module-arguments.md` mentions `config._module.args.pkgs` in one line without saying it decouples you from the input, and for `lib` it offers flake `follows` as the only route.

## What the page says

- **Choosing `pkgs`.** flake-parts' own definition is wrapped in `lib.mkOptionDefault` (`modules/nixpkgs.nix`), so a plain definition wins without `mkForce`, and the `inputs'.nixpkgs` thunk is then never forced. A flake with no `nixpkgs` input at all evaluates fine. npins, niv and `fetchTarball` all work the same way.
- **Choosing `lib`.** In a flake, `follows`, as `module-arguments.md` already says. From non-flake code, flake-compat with input overrides, using [flake-compat#87](https://git.lix.systems/lix-project/flake-compat/pulls/87).
- **What does not carry over.** `inputs'` and `self'` need real flakes (`_type == "flake"`) and read `self.inputs`, not the `inputs` passed to `mkFlake`; non-flake sources go through `_module.args` / `specialArgs` instead. Links [#329](https://github.com/hercules-ci/flake-parts/issues/329) for the bigger picture.
- **Complete example.** npins commands plus a `default.nix` with no `flake.nix` anywhere.

Disclaimer: I used a coding agent in the creation of this patch.
