### PR TITLE
Fix conan-flake baseUrl to use Codeberg's

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -163,7 +163,7 @@
           };
 
           conan-flake = {
-            baseUrl = "https://codeberg.org/tarcisio/conan-flake";
+            baseUrl = "https://codeberg.org/tarcisio/conan-flake/src/branch/main";
             flakeRef = "git+https://codeberg.org/tarcisio/conan-flake";
             intro = ''
               **Declarative Configuration for the Conan C/C++ Package Manager**


### PR DESCRIPTION
Projects hosted by Codeberg have their source code exposed using this
base URL:  `https://codeberg.org/<OWNER>/<PROJECT>/src/branch/<BRANCHNAME>`

So change conan-flake's `baseUrl` to follow this template.